### PR TITLE
glad opengl loading instead of GLEW

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,19 +3,13 @@ file(GLOB implementation_lib_files
 )
 add_library(Example-00-Implementation ${implementation_lib_files})
 find_package(glfw3 CONFIG REQUIRED)
-find_package(GLEW REQUIRED)
+find_package(glad REQUIRED)
 target_link_libraries(Example-00-Implementation
 	PUBLIC
 		${PROJECT_NAME}
 		glfw
-		GLEW::GLEW
+		glad::glad
 )
-if (UNIX)
-target_link_libraries(Example-00-Implementation
-    PUBLIC
-        GL
-)
-endif()
 set_property(TARGET Example-00-Implementation PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<TARGET_FILE_DIR:Example-00-Implementation>)
 # cmake function for adding an example project
 function(add_example Name)

--- a/examples/Example-00-Implementation/impl.c
+++ b/examples/Example-00-Implementation/impl.c
@@ -10,9 +10,9 @@
 	be used if you run your project in debug configuration. If you don't even want to run these macros in debug configuration, you can define the macro GLD_ACTIVE as 0 before including the backend.
 */
 
-#include <GL/glew.h> //You need to include opengl bindings before implementing the opengl33 backend. You can use any Opengl loading library that you prefeer.
-#define TUIC_OPENGL33_LOAD_GLEW //specify that glew is the library being used.
-//#define TUIC_OPENGL33_LOAD_GLAD //specify this instead of previous macro to use GLAD instead of GLEW.
+#include <glad/glad.h> //You need to include opengl bindings before implementing the opengl33 backend. You can use any Opengl loading library that you prefeer.
+#define TUIC_OPENGL33_LOAD_GLAD //specify that glad is the library being used.
+//#define TUIC_OPENGL33_LOAD_GLEW //specify this instead of previous macro to use GLEW instead of GLAD.
 //#define TUIC_OPENGL33_LOAD_NONE //specify this to use no loading library. This will cause @ref tuiOpengl33InstanceCreateNewContext to return NULL.
 #define TUIC_OPENGL33_IMPLEMENTATION // Including this before the header tells the compiler to implement the opengl33 backend.
 //#define GLD_ACTIVE 0 //disable glDebug debugging library (increases performance in debug configuration builds for opengl33 backend)

--- a/examples/Example-01-Basic-Panel/main.c
+++ b/examples/Example-01-Basic-Panel/main.c
@@ -1,6 +1,6 @@
 /* This example showcases how to use a panel that uses JTUI_DETAIL_G8_C4 detail mode. This detail mode has 8 bits per glyph and 4 bits per color. This allows for up to 256 unique glyphs and for a palette of 16 colors. */
 
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-02-Channel-Replace-Blend-Modes/main.c
+++ b/examples/Example-02-Channel-Replace-Blend-Modes/main.c
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-03-Panel-Transformed-Rendering/main.c
+++ b/examples/Example-03-Panel-Transformed-Rendering/main.c
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-04-Dynamic-Resizing/main.c
+++ b/examples/Example-04-Dynamic-Resizing/main.c
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-05-Basic-Text-Rendering/main.c
+++ b/examples/Example-05-Basic-Text-Rendering/main.c
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-06-Simple-Topdown-Character/main.c
+++ b/examples/Example-06-Simple-Topdown-Character/main.c
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-07-Mouse-Input/main.c
+++ b/examples/Example-07-Mouse-Input/main.c
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-08-Matrix-Rain/main.c
+++ b/examples/Example-08-Matrix-Rain/main.c
@@ -1,6 +1,6 @@
 /*  */
 
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/include/TUIC/backends/objects.h
+++ b/include/TUIC/backends/objects.h
@@ -70,7 +70,7 @@ typedef void(*tuiInstanceResizeScreenCallback)(TuiInstance instance, size_t scre
  * @param top_y The topmost pixel to draw the batch data in the screen of the @ref TuiInstance.
  * @param bottom_y The bottommost pixel to draw the batch data in the screen of the @ref TuiInstance.
  */
-typedef void(*tuiInstanceDrawBatchDataCallback) (TuiInstance instance, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y);
+typedef void(*tuiInstanceDrawBatchDataCallback) (TuiInstance instance, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, const uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y);
 /*!
  * @brief Callback type used for creating the API data of a @ref TuiGlyphAtlas.
  * 

--- a/include/TUIC/backends/opengl33_implementation.in
+++ b/include/TUIC/backends/opengl33_implementation.in
@@ -39,14 +39,14 @@ extern "C" {
 void InstanceDestroy_Opengl33(TuiInstance instance);
 void InstanceClearColor_Opengl33(TuiInstance instance, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 void InstanceResizeScreen_Opengl33(TuiInstance instance, size_t screen_width, size_t screen_height);
-void InstanceDrawBatchData_Opengl33(TuiInstance instance, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y);
-void GlyphAtlasCreate_Opengl33(TuiGlyphAtlas atlas, uint8_t* pixel_data, float* raw_glyph_uvs);
+void InstanceDrawBatchData_Opengl33(TuiInstance instance, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, const uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y);
+void GlyphAtlasCreate_Opengl33(TuiGlyphAtlas atlas, const uint8_t* pixel_data, const float* raw_glyph_uvs);
 void GlyphAtlasDestroy_Opengl33(TuiGlyphAtlas atlas);
-void PaletteCreate_Opengl33(TuiPalette palette, uint8_t* color_data);
+void PaletteCreate_Opengl33(TuiPalette palette, const uint8_t* color_data);
 void PaletteDestroy_Opengl33(TuiPalette palette);
 void PanelCreate_Opengl33(TuiPanel panel);
 void PanelDestroy_Opengl33(TuiPanel panel);
-void PanelDrawBatchData_Opengl33(TuiPanel panel, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y);
+void PanelDrawBatchData_Opengl33(TuiPanel panel, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, const uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y);
 uint8_t* PanelGetPixels_Opengl33(TuiPanel panel, size_t* width, size_t* height, uint8_t* pixel_ptr);
 void PanelRender_Opengl33(TuiPanel panel, int left_x, int right_x, int top_y, int bottom_y);
 void PanelRenderToPanel_Opengl33(TuiPanel panel, TuiPanel target_panel, int left_x, int right_x, int top_y, int bottom_y);
@@ -269,7 +269,7 @@ inline int GetBlendModeUniformValue(int blend_mode)
 		return 0;
 	}
 }
-inline void DrawBatchData(uint32_t framebuffer_handle, size_t framebuffer_width, size_t framebuffer_height, TuiInstance instance, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t blend_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, uint8_t* batch_data, const float* matrix)
+inline void DrawBatchData(uint32_t framebuffer_handle, size_t framebuffer_width, size_t framebuffer_height, TuiInstance instance, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t blend_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, const uint8_t* batch_data, const float* matrix)
 {
 	TuiOpengl33GlyphAtlasApiData* atlas_data = (TuiOpengl33GlyphAtlasApiData*)atlas->ApiData;
 	TuiOpengl33PaletteApiData* palette_data = NULL;
@@ -480,7 +480,7 @@ void InstanceResizeScreen_Opengl33(TuiInstance instance, size_t screen_width, si
 	GLD_CALL(glViewport(0, 0, screen_width, screen_height));
 }
 
-void InstanceDrawBatchData_Opengl33(TuiInstance instance, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y)
+void InstanceDrawBatchData_Opengl33(TuiInstance instance, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, const uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y)
 {
 	TuiOpengl33InstanceApiData* instance_data = (TuiOpengl33InstanceApiData*)instance->ApiData;
 	float* transformed_matrix = (float*)tuiAllocate(sizeof(float) * 16);
@@ -515,7 +515,7 @@ void InstanceClearColor_Opengl33(TuiInstance instance, uint8_t r, uint8_t g, uin
 	GLD_CALL(glClearColor((float)r / 255.0f, (float)g / 255.0f, (float)b / 255.0f, (float)a / 255.0f));
 	GLD_CALL(glClear(GL_COLOR_BUFFER_BIT));
 }
-void GlyphAtlasCreate_Opengl33(TuiGlyphAtlas atlas, uint8_t* pixel_data, float* raw_glyph_uvs)
+void GlyphAtlasCreate_Opengl33(TuiGlyphAtlas atlas, const uint8_t* pixel_data, const float* raw_glyph_uvs)
 {
 	atlas->ApiData = (TuiOpengl33GlyphAtlasApiData*)tuiAllocate(sizeof(TuiOpengl33GlyphAtlasApiData));
 	TuiOpengl33GlyphAtlasApiData* atlas_data = (TuiOpengl33GlyphAtlasApiData*)atlas->ApiData;
@@ -573,7 +573,7 @@ void GlyphAtlasDestroy_Opengl33(TuiGlyphAtlas atlas)
 	}
 	tuiFree(atlas_data);
 }
-void PaletteCreate_Opengl33(TuiPalette palette, uint8_t* color_data)
+void PaletteCreate_Opengl33(TuiPalette palette, const uint8_t* color_data)
 {
 	palette->ApiData = (TuiOpengl33PaletteApiData*)tuiAllocate(sizeof(TuiOpengl33PaletteApiData));
 	TuiOpengl33PaletteApiData* palette_data = (TuiOpengl33PaletteApiData*)palette->ApiData;
@@ -620,7 +620,7 @@ void PanelDestroy_Opengl33(TuiPanel panel)
 	}
 	tuiFree(panel_data);
 }
-void PanelDrawBatchData_Opengl33(TuiPanel panel, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y)
+void PanelDrawBatchData_Opengl33(TuiPanel panel, TuiGlyphAtlas atlas, TuiPalette palette, size_t detail_mode, size_t tiles_wide, size_t tiles_tall, size_t sparse_index, const uint8_t* batch_data, int left_x, int right_x, int top_y, int bottom_y)
 {
 	TuiOpengl33PanelApiData* panel_data = (TuiOpengl33PanelApiData*)panel->ApiData;
 	float* transformed_matrix = (float*)tuiAllocate(sizeof(float) * 16);

--- a/include/TUIC/backends/opengl33_implementation.in
+++ b/include/TUIC/backends/opengl33_implementation.in
@@ -458,7 +458,7 @@ TuiInstance tuiOpengl33InstanceCreate(int pixel_width, int pixel_height, void* w
     }
 #endif
 #ifdef TUIC_OPENGL33_LOAD_GLAD
-	if (!gladLoadGLL_LOAD_oader((GLADloadproc)window_proc_address))
+	if (!gladLoadGLLoader((GLADloadproc)window_proc_address))
 	{
 		tuiDebugError(TUI_ERROR_BACKEND_SPECIFIC, "Failed to initialize GLAD.");
         return NULL;

--- a/include/TUIC/backends/opengl33_implementation.in
+++ b/include/TUIC/backends/opengl33_implementation.in
@@ -121,7 +121,7 @@ void gld_message(const char* a, const char* b)
 inline void CreateFramebuffer(uint32_t* framebuffer_handle, uint32_t* texture_handle, uint32_t* renderbuffer_handle, size_t width, size_t height)
 {
 	GLD_CLEAR();
-	GLD_CALL(glCreateFramebuffers(1, framebuffer_handle));
+	GLD_CALL(glGenFramebuffers(1, framebuffer_handle));
 	GLD_CALL(glBindFramebuffer(GL_FRAMEBUFFER, *framebuffer_handle));
 	GLD_CALL(glGenTextures(1, texture_handle));
 	GLD_CALL(glBindTexture(GL_TEXTURE_2D, *texture_handle));

--- a/test/auto/CMakeLists.txt
+++ b/test/auto/CMakeLists.txt
@@ -12,7 +12,6 @@ target_link_libraries(TUIC_TESTS_AUTO
 		Catch2::Catch2
 		${PROJECT_NAME}
 )
-
 include(CTest)
 include(Catch)
 catch_discover_tests(

--- a/test/manual/CMakeLists.txt
+++ b/test/manual/CMakeLists.txt
@@ -8,12 +8,12 @@ add_executable(TUIC_TESTS_MANUAL
 	test_impl.cpp
 )
 find_package(glfw3 CONFIG REQUIRED)
-find_package(GLEW REQUIRED)
+find_package(glad CONFIG REQUIRED)
 target_link_libraries(TUIC_TESTS_MANUAL
 	PUBLIC
 		${PROJECT_NAME}
 		glfw
-		GLEW::GLEW
+		glad::glad
 )
 file(GLOB asset_files
 	assets/*

--- a/test/manual/opengl33_test.cpp
+++ b/test/manual/opengl33_test.cpp
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glad/glad.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/test/manual/test_impl.cpp
+++ b/test/manual/test_impl.cpp
@@ -1,5 +1,5 @@
-#include <GL/glew.h>
-#define TUIC_OPENGL33_LOAD_GLEW
+#include <glad/glad.h>
+#define TUIC_OPENGL33_LOAD_GLAD
 #define TUIC_OPENGL33_IMPLEMENTATION
 #include <TUIC/backends/opengl33_implementation.h>
 


### PR DESCRIPTION
GLEW has been replaced with glad. This change has been made because of an error when building GLEW with vcpkg on Linux. glad has gained more popularity than GLEW lately and seems to be better maintained.