### PR TITLE
build manual testing in CI

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -33,6 +33,10 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}
         run: git submodule add https://github.com/microsoft/vcpkg vcpkg/
+      - name: add linux system packages
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: sudo apt install libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev
       - uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/vcpkg/

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -38,12 +38,14 @@ jobs:
       - name: install Catch2
         shell: bash
         working-directory: ${{ matrix.platform.vcpkgdir }}
-        run: vcpkg install catch2 --triplet ${{ matrix.platform.arch }} 
+        run: vcpkg install catch2 --triplet ${{ matrix.platform.arch }}
+      - name: list packages in vcpkg
+        shell: bash
+        run:  vcpkg list
       - name: cmake build
         shell: bash
         working-directory: ${{github.workspace}}
         run: |
-             vcpkg list
              cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DTUIC_BUILD_AUTO_TESTS=ON -DTUIC_OPENGL33_BACKEND=OFF -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
              cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.build_type }}
         continue-on-error: true

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       triplet: x64-windows,   vcpkgdir: "C:\\vcpkg\\downloads" }
-        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       triplet: x64-linux,     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   triplet: x64-linux,     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      triplet: x64-linux,     vcpkgdir: "/usr/local/share/vcpkg"  }
+        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       triplet: "x64-windows",   vcpkgdir: "C:\\vcpkg\\downloads" }
+        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       triplet: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
+        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   triplet: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
+        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      triplet: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg"  }
         build_type: [Release, Debug]
     env:
       buildDir: '${{ github.workspace }}\build'

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows",   vcpkgdir: "C:/vcpkg/downloads" }
+        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows",   vcpkgdir: "C:/vcpkg/" }
         - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
         - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
         - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg"  }

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -11,8 +11,8 @@ jobs:
         platform:
         - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       triplet: x64-windows,   vcpkgdir: "C:\\vcpkg\\downloads" }
         - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       triplet: x64-linux,     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   triplet: x64-linux, vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      triplet: x64-linux,    vcpkgdir: "/usr/local/share/vcpkg"  }
+        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   triplet: x64-linux,     vcpkgdir: "/usr/local/share/vcpkg" }
+        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      triplet: x64-linux,     vcpkgdir: "/usr/local/share/vcpkg"  }
         build_type: [Release, Debug]
     env:
       buildDir: '${{ github.workspace }}\build'
@@ -30,7 +30,7 @@ jobs:
         run: cmake -E make_directory $GITHUB_WORKSPACE/build
       - uses: actions/cache@v2
         with:
-          path: ${{ matrix.vcpkgdir }}
+          path: ${{ matrix.vcpkgdir }}/downloads
           key: ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows",   vcpkgdir: "C:\\vcpkg\\downloads" }
+        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows",   vcpkgdir: "C:/vcpkg/downloads" }
         - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
         - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
         - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg"  }

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,   triplet: x64-windows,   vcpkgdir: C:\vcpkg\downloads }
-        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,   triplet: x64-linux,     vcpkgdir: /usr/local/share/vcpkg }
-        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   triplet: x64-linux, vcpkgdir: /usr/local/share/vcpkg }
-        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,   triplet: x64-linux,    vcpkgdir: /usr/local/share/vcpkg  }
+        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       triplet: x64-windows,   vcpkgdir: "C:\\vcpkg\\downloads" }
+        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       triplet: x64-linux,     vcpkgdir: "/usr/local/share/vcpkg" }
+        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   triplet: x64-linux, vcpkgdir: "/usr/local/share/vcpkg" }
+        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      triplet: x64-linux,    vcpkgdir: "/usr/local/share/vcpkg"  }
         build_type: [Release, Debug]
     env:
       buildDir: '${{ github.workspace }}\build'

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ${{ matrix.platform.os }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
         - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows" }

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: install Catch2
         shell: bash
         working-directory: ${{ matrix.vcpkgdir }}
-        run: vcpkg install catch2 --triplet=${{ matrix.triplet }} 
+        run: vcpkg install catch2 --triplet ${{ matrix.triplet }} 
       - name: cmake build
         shell: bash
         working-directory: ${{github.workspace}}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       triplet: "x64-windows",   vcpkgdir: "C:\\vcpkg\\downloads" }
-        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       triplet: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   triplet: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      triplet: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg"  }
+        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows",   vcpkgdir: "C:\\vcpkg\\downloads" }
+        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
+        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
+        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg"  }
         build_type: [Release, Debug]
     env:
       buildDir: '${{ github.workspace }}\build'
@@ -38,7 +38,7 @@ jobs:
       - name: install Catch2
         shell: bash
         working-directory: ${{ matrix.vcpkgdir }}
-        run: vcpkg install catch2 --triplet ${{ matrix.triplet }} 
+        run: vcpkg install catch2 --triplet ${{ matrix.arch }} 
       - name: cmake build
         shell: bash
         working-directory: ${{github.workspace}}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: bootstrap vcpkg
         shell: bash
         working-directory: ${{ github.workspace }}/vcpkg/
-        run: ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+        run: ./bootstrap-vcpkg.sh -disableMetrics
       - name: install packages
         shell: bash
         working-directory: ${{ github.workspace }}/vcpkg/

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -12,7 +12,7 @@ jobs:
         - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows",   vcpkgdir: "C:/vcpkg/" }
         - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
         - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-osx",     vcpkgdir: "/usr/local/share/vcpkg"  }
+        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-osx",       vcpkgdir: "/usr/local/share/vcpkg"  }
         build_type: [Release, Debug]
     env:
       buildDir: '${{ github.workspace }}\build'
@@ -35,21 +35,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-
             ${{ runner.os }}-vcpkg-download-
-      - name: install Catch2
+      - name: install packages
         shell: bash
         working-directory: ${{ matrix.platform.vcpkgdir }}
-        run: vcpkg install catch2 --triplet ${{ matrix.platform.arch }}
+        run: vcpkg install catch2 glew glfw3 --triplet ${{ matrix.platform.arch }}
       - name: list packages in vcpkg
         shell: bash
         run:  vcpkg list
-      - name: cmake build
+      - name: cmake build tests
         shell: bash
         working-directory: ${{github.workspace}}
         run: |
-             cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DTUIC_BUILD_AUTO_TESTS=ON -DTUIC_OPENGL33_BACKEND=OFF -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+             cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DTUIC_BUILD_AUTO_TESTS=ON -DTUIC_OPENGL33_BACKEND=ON -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
              cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.build_type }}
         continue-on-error: true
-      - name: run tests
+      - name: run auto tests
         shell: bash
         working-directory: ${{github.workspace}}/build/test/auto/
         run: ctest -C ${{ matrix.build_type }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -12,7 +12,7 @@ jobs:
         - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows",   vcpkgdir: "C:/vcpkg/" }
         - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
         - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg"  }
+        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-osx",     vcpkgdir: "/usr/local/share/vcpkg"  }
         build_type: [Release, Debug]
     env:
       buildDir: '${{ github.workspace }}\build'

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -36,10 +36,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ matrix.platform.os }}-
             ${{ runner.os }}-vcpkg-download-
-      - name: add vcpkg submodule
+      - name: add vcpkg
         shell: bash
         working-directory: ${{ github.workspace }}
-        run: git submodule add https://github.com/microsoft/vcpkg vcpkg/
+        run: git clone https://github.com/microsoft/vcpkg vcpkg/
       - name: bootstrap vcpkg
         shell: bash
         working-directory: ${{ github.workspace }}/vcpkg/

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: cmake --version
       - name: create build enviornment
         shell: bash
-        working-directory: ${{ github.workspace }
+        working-directory: ${{ github.workspace }}
         run: cmake -E make_directory $GITHUB_WORKSPACE/build
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: install packages
         shell: bash
         working-directory: ${{ github.workspace }}/vcpkg/
-        run: ./vcpkg install catch2 glew glfw3 --triplet ${{ matrix.platform.arch }}
+        run: ./vcpkg install catch2 glad glfw3 --triplet ${{ matrix.platform.arch }}
       - name: list packages in vcpkg
         shell: bash
         working-directory: ${{ github.workspace }}/vcpkg/

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -39,11 +39,11 @@ jobs:
         run: sudo apt install libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev
       - uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/vcpkg/
-          key: ${{ runner.os }}-vcpkg-download-${{ matrix.platform.os }}-${{ github.sha }}
+          path: ${{ github.workspace }}/vcpkg/downloads/
+          key: ${{ runner.os }}-vcpkg-downloads-${{ matrix.platform.os }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ matrix.platform.os }}-
-            ${{ runner.os }}-vcpkg-download-
+            ${{ runner.os }}-vcpkg-downloads-${{ matrix.platform.os }}-
+            ${{ runner.os }}-vcpkg-downloads-
       - name: bootstrap vcpkg
         shell: bash
         working-directory: ${{ github.workspace }}/vcpkg/

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -29,6 +29,10 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}
         run: cmake -E make_directory $GITHUB_WORKSPACE/build
+      - name: add vcpkg submodule
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: git submodule add https://github.com/microsoft/vcpkg vcpkg/
       - uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/vcpkg/
@@ -36,10 +40,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ matrix.platform.os }}-
             ${{ runner.os }}-vcpkg-download-
-      - name: add vcpkg submodule
-        shell: bash
-        working-directory: ${{ github.workspace }}
-        run: git submodule add https://github.com/microsoft/vcpkg vcpkg/
       - name: bootstrap vcpkg
         shell: bash
         working-directory: ${{ github.workspace }}/vcpkg/

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,4 +1,7 @@
-name: AutoTest
+#Compile manual tests to check for compile errors
+#Compile automatic tests and run them, outputting errors
+
+name: Tests
 on: [push]
 jobs:
   build:
@@ -6,10 +9,10 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe }
-        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10 }
-        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12 }
-        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++  }
+        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,   triplet: x64-windows,   vcpkgdir: C:\vcpkg\downloads }
+        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,   triplet: x64-linux,     vcpkgdir: /usr/local/share/vcpkg }
+        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   triplet: x64-linux, vcpkgdir: /usr/local/share/vcpkg }
+        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,   triplet: x64-linux,    vcpkgdir: /usr/local/share/vcpkg  }
         build_type: [Release, Debug]
     env:
       buildDir: '${{ github.workspace }}\build'
@@ -26,44 +29,16 @@ jobs:
         working-directory: ${{github.workspace}}
         run: cmake -E make_directory $GITHUB_WORKSPACE/build
       - uses: actions/cache@v2
-        if: runner.os == 'Windows'
         with:
-          path: C:\vcpkg\downloads
+          path: ${{ matrix.vcpkgdir }}
           key: ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-
             ${{ runner.os }}-vcpkg-download-
-      - name: install catch2 with vcpkg (windows)
-        if: runner.os == 'Windows'
+      - name: install Catch2
         shell: bash
-        working-directory: C:\vcpkg
-        run: vcpkg install catch2:x64-windows
-      - uses: actions/cache@v2
-        if: runner.os == 'Linux'
-        with:
-          path: \usr\local\share\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-
-            ${{ runner.os }}-vcpkg-download-
-      - name: install catch2 with vcpkg (linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        working-directory: /usr/local/share/vcpkg
-        run: vcpkg install catch2:x64-linux
-      - uses: actions/cache@v2
-        if: runner.os == 'macOS'
-        with:
-          path: \usr\local\share\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-
-            ${{ runner.os }}-vcpkg-download-
-      - name: install catch2 with vcpkg (macos)
-        if: runner.os == 'macOS'
-        shell: bash
-        working-directory: /usr/local/share/vcpkg
-        run: vcpkg install catch2:x64-osx
+        working-directory: ${{ matrix.vcpkgdir }}
+        run: vcpkg install catch2 --triplet ${{ matrix.triplet }} 
       - name: cmake build
         shell: bash
         working-directory: ${{github.workspace}}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: install Catch2
         shell: bash
         working-directory: ${{ matrix.vcpkgdir }}
-        run: vcpkg install catch2 --triplet ${{ matrix.triplet }} 
+        run: vcpkg install catch2 --triplet=${{ matrix.triplet }} 
       - name: cmake build
         shell: bash
         working-directory: ${{github.workspace}}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -70,3 +70,8 @@ jobs:
           report_paths: '**/unittests.*.xml'
           require_tests: true
           fail_on_failure: true
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: vcpkg-logs
+          path: ${{github.workspace}}/vcpkg/buildtrees/*/*.log #

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -36,10 +36,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ matrix.platform.os }}-
             ${{ runner.os }}-vcpkg-download-
-      - name: add vcpkg
+      - name: add vcpkg submodule
         shell: bash
         working-directory: ${{ github.workspace }}
-        run: git clone https://github.com/microsoft/vcpkg vcpkg/
+        run: git submodule add https://github.com/microsoft/vcpkg vcpkg/
       - name: bootstrap vcpkg
         shell: bash
         working-directory: ${{ github.workspace }}/vcpkg/

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows",   vcpkgdir: "C:/vcpkg/" }
-        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   arch: "x64-linux",     vcpkgdir: "/usr/local/share/vcpkg" }
-        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-osx",       vcpkgdir: "/usr/local/share/vcpkg"  }
+        - { Name: Windows VS2019, os: windows-2019, cc: cl.exe,    cxx: cl.exe,       arch: "x64-windows" }
+        - { Name: Linux GCC,      os: ubuntu-20.04, cc: gcc-10,    cxx: g++-10,       arch: "x64-linux" }
+        - { Name: Linux Clang,    os: ubuntu-20.04, cc: clang-12,  cxx: clang++-12,   arch: "x64-linux" }
+        - { Name: MacOS Clang,    os: macos-10.15,  cc: clang,     cxx: clang++,      arch: "x64-osx"  }
         build_type: [Release, Debug]
     env:
       buildDir: '${{ github.workspace }}\build'
@@ -26,27 +26,36 @@ jobs:
         run: cmake --version
       - name: create build enviornment
         shell: bash
-        working-directory: ${{github.workspace}}
+        working-directory: ${{ github.workspace }
         run: cmake -E make_directory $GITHUB_WORKSPACE/build
       - uses: actions/cache@v2
         with:
-          path: ${{ matrix.platform.vcpkgdir }}/downloads
+          path: ${{ github.workspace }}/vcpkg/
           key: ${{ runner.os }}-vcpkg-download-${{ matrix.platform.os }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-
+            ${{ runner.os }}-vcpkg-download-${{ matrix.platform.os }}-
             ${{ runner.os }}-vcpkg-download-
+      - name: add vcpkg submodule
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: git submodule add https://github.com/microsoft/vcpkg vcpkg/
+      - name: bootstrap vcpkg
+        shell: bash
+        working-directory: ${{ github.workspace }}/vcpkg/
+        run: ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
       - name: install packages
         shell: bash
-        working-directory: ${{ matrix.platform.vcpkgdir }}
-        run: vcpkg install catch2 glew glfw3 --triplet ${{ matrix.platform.arch }}
+        working-directory: ${{ github.workspace }}/vcpkg/
+        run: ./vcpkg install catch2 glew glfw3 --triplet ${{ matrix.platform.arch }}
       - name: list packages in vcpkg
         shell: bash
-        run:  vcpkg list
+        working-directory: ${{ github.workspace }}/vcpkg/
+        run:  ./vcpkg list
       - name: cmake build tests
         shell: bash
         working-directory: ${{github.workspace}}
         run: |
-             cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DTUIC_BUILD_AUTO_TESTS=ON -DTUIC_OPENGL33_BACKEND=ON -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+             cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DTUIC_BUILD_AUTO_TESTS=ON -DTUIC_OPENGL33_BACKEND=ON -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/vcpkg/scripts/buildsystems/vcpkg.cmake
              cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.build_type }}
         continue-on-error: true
       - name: run auto tests

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,9 +24,6 @@ jobs:
       - name: log CMake version
         shell: bash
         run: cmake --version
-      - name: update vcpkg portfiles
-        shell: bash
-        run: vcpkg update
       - name: create build enviornment
         shell: bash
         working-directory: ${{github.workspace}}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -30,15 +30,15 @@ jobs:
         run: cmake -E make_directory $GITHUB_WORKSPACE/build
       - uses: actions/cache@v2
         with:
-          path: ${{ matrix.vcpkgdir }}/downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-${{ github.sha }}
+          path: ${{ matrix.platform.vcpkgdir }}/downloads
+          key: ${{ runner.os }}-vcpkg-download-${{ matrix.platform.os }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-
             ${{ runner.os }}-vcpkg-download-
       - name: install Catch2
         shell: bash
-        working-directory: ${{ matrix.vcpkgdir }}
-        run: vcpkg install catch2 --triplet ${{ matrix.arch }} 
+        working-directory: ${{ matrix.platform.vcpkgdir }}
+        run: vcpkg install catch2 --triplet ${{ matrix.platform.arch }} 
       - name: cmake build
         shell: bash
         working-directory: ${{github.workspace}}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,6 +24,9 @@ jobs:
       - name: log CMake version
         shell: bash
         run: cmake --version
+      - name: update vcpkg portfiles
+        shell: bash
+        run: vcpkg update
       - name: create build enviornment
         shell: bash
         working-directory: ${{github.workspace}}


### PR DESCRIPTION
Build the manual testing framework in Github Actions to make sure that the backends compile on all platforms without errors. Since there is no use in running the manual tests without anyone reviewing them, they are only built and not run.